### PR TITLE
Sysex use valid sub-sequence

### DIFF
--- a/src/interface/private/AxeSystem_Midi.cpp
+++ b/src/interface/private/AxeSystem_Midi.cpp
@@ -23,10 +23,13 @@ void AxeSystem::readMidi() {
     byte data = SER_READ;
 
     if (_readingSysex) {
+      if (data == SystemExclusive)
+        _sysexCount = 0;
 
       _sysexBuffer[_sysexCount++] = data;
       if (data == SYSEX_END) {
         _readingSysex = false;
+
         if (validateSysEx(_sysexBuffer, _sysexCount)) {
           onSystemExclusive(_sysexBuffer, _sysexCount);
         } else {


### PR DESCRIPTION
During testing I found I was frequently getting the message ******** AxeSystem::readMidi(): INVALID SYSEX ...
In particular this was caused by the realtime sysex from AxeFx sending the tempo. 

I eventually found that by increasing the serial buffer size in the hardware RingBuffer.cpp I could avoid this issue. However prior to finding that I decided to implement a change to this library to make use of valid sub sequences of sysex data. For example:
0xF0 0x00 0xF0 0x00 0x01 0x74 0x10 0x0E 0x00 0x35 0x46 0x32 0x20 0x20 0x20 0x20 0x20 0x20 0x20 
   .... 0x5A 0xF7
Has the start of a tempo sysex and then a valid scene name receive. Currently the library will just show this message as invalid. My change will remove the first 2 bytes in the above example. 
The first message is still lost so not a solution to buffer overrun but is better than nothing.

This does have a slight performance hit in that when we process a sysex message we have to loop through the message an additional time + shift the array data left. Alternatively we could record the index of the valid sequence and pass this around so functions like onSystemExclusive accepting a starting index. I didn't take this approach due to the extra refactoring required but happy to do that instead.