### PR TITLE
Allow the loading of preset details other than the currently selected

### DIFF
--- a/src/interface/private/AxeSystem_Handlers.cpp
+++ b/src/interface/private/AxeSystem_Handlers.cpp
@@ -56,12 +56,9 @@ void AxeSystem::onSystemExclusive(const byte *sysex, const byte length) {
       requestSceneName(); // next item in chain
       checkIncomingPreset();
     } else {
-#ifdef AXE_DEBUG
-      DEBUGGER.print("Dropping stale preset name packet ");
-      DEBUGGER.print(number);
-      DEBUGGER.print(", waiting for ");
-      DEBUGGER.println(_incomingPreset.getPresetNumber());
-#endif
+      // We aren't updating current preset, just firing callback
+      parseName(sysex, length, 8, buffer, max);
+      callPresetNameCallback(number, (const char *)buffer, max);
     }
 
     break;


### PR DESCRIPTION
Currently preset name loads where the preset number is not the currently selected preset will be dropped because they are viewed as stale data.

I've changed this so that it doesn't update the current presset name at all but still passes details to the callback. This is so we can show a bank of preset names and choose between them by name.

I haven't found this causing any issues, however if people using this library wrote their callbacks on the assumption that it would only ever contain the selected preset name this could be an issue.