### PR TITLE
Support other fractal products (FM3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ the library.
 		// and then just call Axe.update() in the main loop and you are ready to roll.
 		AxeSystem();
 
+		// By default AxeFxIII will be assumed. This constructor allows another product such as FM3 to be used
+		// For AxeFx3 pass 0x10 (default)
+		// For FM3 pass 0x11		
+		AxeSystem(byte sysexFractalVersion);
+
 		// You must call begin with a hardware serial such as Serial1. Optionally set the 
 		// MIDI channel, defaults to OMNI.
 		// You cannot call this more than once. (Well you can, but it will be ignored.)

--- a/src/interface/AxeSystem.h
+++ b/src/interface/AxeSystem.h
@@ -33,7 +33,11 @@ enum class UpdateMode {
 class AxeSystem {
 
 public:
-  AxeSystem(byte sysexFractalVersion = SYSEX_AXE_VERSION) {
+
+  const static byte FRACTAL_PRODUCT_AXEFX3 = 0x10;
+  const static byte FRACTAL_PRODUCT_FM3 = 0x11;
+
+  AxeSystem(byte sysexFractalVersion = FRACTAL_PRODUCT_AXEFX3) {
     _sysexFractalVersion = sysexFractalVersion;
     _looper.setAxeSystem(this);
   }

--- a/src/interface/AxeSystem.h
+++ b/src/interface/AxeSystem.h
@@ -34,6 +34,12 @@ class AxeSystem {
 
 public:
   AxeSystem() {
+    _sysexAxeVersion = SYSEX_AXE_VERSION;
+    _looper.setAxeSystem(this);
+  }
+
+  AxeSystem(byte sysexFractalVersion) {
+    _sysexFractalVersion = sysexFractalVersion;
     _looper.setAxeSystem(this);
   }
 

--- a/src/interface/AxeSystem.h
+++ b/src/interface/AxeSystem.h
@@ -33,12 +33,7 @@ enum class UpdateMode {
 class AxeSystem {
 
 public:
-  AxeSystem() {
-    _sysexAxeVersion = SYSEX_AXE_VERSION;
-    _looper.setAxeSystem(this);
-  }
-
-  AxeSystem(byte sysexFractalVersion) {
+  AxeSystem(byte sysexFractalVersion = SYSEX_AXE_VERSION) {
     _sysexFractalVersion = sysexFractalVersion;
     _looper.setAxeSystem(this);
   }

--- a/src/interface/private/AxeSystem_Midi.cpp
+++ b/src/interface/private/AxeSystem_Midi.cpp
@@ -145,7 +145,7 @@ void AxeSystem::sendCommand(const byte command, const byte *data, const byte par
   sysex[length++] = SYSEX_MANUFACTURER_BYTE1;
   sysex[length++] = SYSEX_MANUFACTURER_BYTE2;
   sysex[length++] = SYSEX_MANUFACTURER_BYTE3;
-  sysex[length++] = SYSEX_AXE_VERSION;
+  sysex[length++] = _sysexFractalVersion;
   sysex[length++] = command;
 
   //optional data

--- a/src/interface/private/AxeSystem_Private.h
+++ b/src/interface/private/AxeSystem_Private.h
@@ -15,7 +15,6 @@ const static byte SYSEX_EFFECT_ENABLE = 0x00;
 const static byte SYSEX_MANUFACTURER_BYTE1 = 0x00;
 const static byte SYSEX_MANUFACTURER_BYTE2 = 0x01;
 const static byte SYSEX_MANUFACTURER_BYTE3 = 0x74;
-const static byte SYSEX_AXE_VERSION = 0x10;
 const static byte SYSEX_QUERY_BYTE = 0x7F;
 const static byte SYSEX_CHECKSUM_PLACEHOLDER = 0x00;
 

--- a/src/interface/private/AxeSystem_Private.h
+++ b/src/interface/private/AxeSystem_Private.h
@@ -90,6 +90,7 @@ AxeLooper _looper;
 Version _firmwareVersion;
 Version _usbVersion;
 HardwareSerial *_serial = nullptr;
+byte _sysexFractalVersion;
 byte _tempo;
 byte _bank;
 byte _midiChannel;


### PR DESCRIPTION
Fractal forum member was interested in FM3 support. This PR just adds a new constructor to allow the passing of sysex product version.

Backwards compatible as defaults to AxeFx 3.

Adds 1 byte, could replace some of the const static bytes with #defines to bring that down if this is an issue.